### PR TITLE
Diversos ajustes de higienização, responsividade e coerência de projeto

### DIFF
--- a/.github/agents/PENELOPE-WEB-SITE.implementacao.agent.md
+++ b/.github/agents/PENELOPE-WEB-SITE.implementacao.agent.md
@@ -139,7 +139,7 @@ export function ExemploView() {
 
 ## Entidades de Domínio
 
-Criar em `src/app/model/entities/` com:
+Criar em `src/app/dtos/` com:
 
 - Campos privados `#field`
 - Getters e setters
@@ -173,31 +173,31 @@ export class Entidade {
 
 ## Serviços de API
 
-Criar em `src/app/services/penelopec/` — **NUNCA** importar axios diretamente:
+Criar em `src/app/services/penelopec/` usando a API em `src/app/api/` — **NUNCA** importar axios diretamente:
 
 ```javascript
-import axiosInstance from '@penelopec/axiosInstance'
+import * as entidadeApi from '@api-penelopec/entidadeApi'
 import { EntidadeMapper } from '@mappers/EntidadeMapper'
 
 export const listarEntidades = async (filtros = {}) => {
-  const response = await axiosInstance.get('/entidades', { params: filtros })
-  return EntidadeMapper.toEntityList(response.data)
+  const response = await entidadeApi.listarEntidades(filtros)
+  return EntidadeMapper.toEntityList(response)
 }
 
 export const buscarEntidadePorId = async (id) => {
-  const response = await axiosInstance.get(`/entidades/${id}`)
-  return EntidadeMapper.toEntity(response.data)
+  const response = await entidadeApi.buscarEntidadePorId(id)
+  return EntidadeMapper.toEntity(response)
 }
 
 export const criarEntidade = async (entidade) => {
-  const response = await axiosInstance.post('/entidades', entidade.toRequestPayload())
-  return EntidadeMapper.toEntity(response.data)
+  const response = await entidadeApi.criarEntidade(entidade.toRequestPayload())
+  return EntidadeMapper.toEntity(response)
 }
 ```
 
 ## Mappers
 
-Criar em `src/app/services/mapper/` — conversão bidirecional API ↔ Entidade:
+Criar em `src/app/mappers/` — conversão bidirecional API ↔ Entidade:
 
 ```javascript
 import { Entidade } from '@dtos/Entidade'
@@ -228,11 +228,21 @@ export class EntidadeMapper {
 | `@management` | `src/modules/management/` |
 | `@routes` | `src/app/routes/` |
 | `@utils` | `src/shared/utils/` |
+| `@app` | `src/app/` |
+| `@routes` | `src/app/routes/` |
+| `@api` | `src/app/api/` |
 | `@services` | `src/app/services/` |
-| `@api` | `src/app/services/api/` |
-| `@mapper` | `src/app/services/mapper/` |
-| `@entity` | `src/app/model/entities/` |
-| `@constant` | `src/constants/` |
+| `@mappers` | `src/app/mappers/` |
+| `@dtos` | `src/app/dtos/` |
+| `@mocks` | `src/app/mocks/` |
+| `@utils` | `src/shared/utils/` |
+| `@constant` | `src/shared/constants/` |
+| `@service-penelopec` | `src/app/services/penelopec/` |
+| `@service-viacep` | `src/app/services/viacep/` |
+| `@service-calservice` | `src/app/services/calservice/` |
+| `@api-penelopec` | `src/app/api/penelopec/` |
+| `@api-viacep` | `src/app/api/viacep/` |
+| `@api-calservice` | `src/app/api/calservice/` |
 
 ## Estilização — Tailwind CSS 4
 
@@ -263,7 +273,7 @@ Antes de criar componentes novos, verificar se já existe em `src/shared/compone
 
 ## Constantes
 
-Definir em `src/constants/` com `UPPER_SNAKE_CASE` e helpers:
+Definir em `src/shared/constants/` com `UPPER_SNAKE_CASE` e helpers:
 
 ```javascript
 export const TIPOS_EXEMPLO = {
@@ -301,7 +311,7 @@ export function useExemploHook(opcoes = {}) {
 
 ## Rotas
 
-Definir em `src/constants/routes.js`:
+Definir em `src/shared/constants/routes.js`:
 
 ```javascript
 ROTA_EXEMPLO: { key: 'ROTA_EXEMPLO', path: '/exemplo', friendlyName: 'Exemplo' }
@@ -333,5 +343,5 @@ Registrar no `RouterModel.js` no nível de proteção adequado:
 1. Antes de implementar, verificar componentes e padrões existentes no projeto
 2. Criar os três arquivos MVVM na ordem: Model → ViewModel → View
 3. Registrar novas rotas em `constants/routes.js` e `RouterModel.js`
-4. Novas entidades vão em `src/app/model/entities/`, APIs em `src/app/services/api/`, mappers em `src/app/services/mapper/`
+4. Novas entidades vão em `src/app/dtos/`, APIs em `src/app/api/`, serviços em `src/app/services/` e mappers em `src/app/mappers/`
 5. Validar que lint e build passam após cada implementação: `npm run lint` e `npm run build`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,12 +92,11 @@ HomeView.jsx → useHomeViewModel.js → HomeModel.js
 ```
 src/
 ├── app/                    # Core da aplicação
-│   ├── model/entities/     # Classes de domínio (User, Estate, Address, etc.)
+│   ├── api/                # Módulos de API (penelopec, viacep, calservice)
+│   ├── dtos/               # Classes de domínio (User, Estate, Address, etc.)
+│   ├── mappers/            # Conversão API ↔ Entidades de domínio
 │   ├── routes/             # RouterModel, RouterView, useRouterViewModel
-│   └── services/
-│       ├── api/            # Módulos Axios (authApi, realEstateAdvertisementAPI, etc.)
-│       └── mapper/         # Conversão API ↔ Entidades de domínio
-├── constants/              # Constantes globais (routes, estateTypes, imageTypes, etc.)
+│   └── services/           # Camada de orquestração/negócio por integração
 ├── modules/                # Módulos de funcionalidade
 │   ├── auth/               # Autenticação (login, registro, reset senha)
 │   ├── institutional/      # Páginas públicas (Home, Properties, About, Contacts)
@@ -105,6 +104,7 @@ src/
 └── shared/                 # Código reutilizável
     ├── assets/             # Fontes, imagens
     ├── components/         # Componentes compartilhados (layout/, ui/, feedback/)
+    ├── constants/          # Constantes globais (routes, estateTypes, imageTypes, etc.)
     ├── hooks/              # Hooks customizados (useCEPAutoFill, useHeaderHeight)
     ├── pages/              # Páginas genéricas (Loading, NotFound, Unauthorized)
     ├── styles/             # style.css (tokens), theme.js (mapeamento semântico)
@@ -133,10 +133,10 @@ Usar **imports absolutos** via aliases definidos no `vite.config.js`:
 import { ButtonView } from '@shared/components/ui/Button/ButtonView'
 import { formatCurrency } from '@utils/formatCurrencyUtil'
 import { ROUTES } from '@constant/routes'
-import axiosInstance from '@penelopec/axiosInstance'
+import axiosInstance from '@api/axiosInstance'
 ```
 
-Aliases disponíveis: `@shared`, `@institutional`, `@auth`, `@management`, `@routes`, `@utils`, `@services`, `@penelopec`, `@viacep`, `@mappers`, `@dtos`, `@mocks`, `@constant`.
+Aliases disponíveis: `@shared`, `@institutional`, `@auth`, `@management`, `@app`, `@routes`, `@api`, `@services`, `@mappers`, `@dtos`, `@mocks`, `@utils`, `@constant`, `@service-penelopec`, `@service-viacep`, `@service-calservice`, `@api-penelopec`, `@api-viacep`, `@api-calservice`.
 
 **Nunca** usar caminhos relativos longos (`../../../`).
 
@@ -192,7 +192,7 @@ export class RealEstateAdvertisementMapper {
 
 ## Entidades de Domínio
 
-Classes em `src/app/model/entities/` com:
+Classes em `src/app/dtos/` com:
 
 - Campos privados (`#field`)
 - Getters e setters
@@ -214,7 +214,7 @@ export class User {
 
 ## Roteamento
 
-- Rotas definidas como objetos em `src/constants/routes.js` com `key`, `path`, `friendlyName`
+- Rotas definidas como objetos em `src/shared/constants/routes.js` com `key`, `path`, `friendlyName`
 - Três níveis de proteção: `publicRoutes`, `authRequiredRoutes`, `adminRequiredRoutes`
 - Componente `ProtectedRoute` redireciona usuários não autorizados
 - Rotas seguem o padrão MVVM: `RouterModel` → `useRouterViewModel` → `RouterView`
@@ -232,7 +232,7 @@ export class User {
 9. **Sempre** escrever código e comentários em **Português Brasileiro** quando for texto de negócio/UI
 10. **Sempre** validar acessibilidade (atributos `aria-*`, `alt` em imagens, semântica HTML)
 11. **Nunca** usar Redux, Zustand ou gerenciamento de estado global — usar estado local + sessionStorage
-12. **Nunca** importar Axios diretamente — usar `axiosInstance` configurado em `@penelopec/axiosInstance`
+12. **Nunca** importar Axios diretamente — usar `axiosInstance` configurado em `@api/axiosInstance`
 
 ## Scripts Disponíveis
 
@@ -247,4 +247,4 @@ npm run check:prod  # Lint + format check + build
 
 ## Variáveis de Ambiente
 
-Usar `import.meta.env.VITE_*` para acessar variáveis. Arquivos `.env.{mode}` suportados: `development`, `homologation`, `production`.
+Usar variáveis de ambiente via `import.meta.env.*` conforme `vite.config.js` (ex.: `VITE_API_BASE_URL`, `VITE_CAL_SERVICE_URL`, `VITE_VIACEP_BASE_URL`). Arquivos `.env.{mode}` suportados: `development`, `homologation`, `production`.

--- a/src/app/dtos/Estate.js
+++ b/src/app/dtos/Estate.js
@@ -11,7 +11,6 @@ import { IMAGE_TYPES } from '@constant/imageTypes'
  * - #numberOfRooms
  * - #type
  * - #address
- * - #standAddress
  * - #images (Array<ImageEstate>)
  * - #amenities (Array<Feature>)
  *
@@ -25,7 +24,6 @@ export class Estate {
   #numberOfRooms
   #type
   #address
-  #standAddress
   #images
   #amenities
 
@@ -37,7 +35,6 @@ export class Estate {
     numberOfRooms,
     type,
     address,
-    standAddress,
     images = [],
     amenities = [],
   }) {
@@ -48,7 +45,6 @@ export class Estate {
     this.#numberOfRooms = numberOfRooms
     this.#type = type
     this.#address = address
-    this.#standAddress = standAddress
     this.#images = images
     this.#amenities = amenities
   }
@@ -76,9 +72,6 @@ export class Estate {
 
   get address() { return this.#address }
   set address(value) { this.#address = value }
-
-  get standAddress() { return this.#standAddress }
-  set standAddress(value) { this.#standAddress = value }
 
   get images() { return this.#images }
   set images(value) { this.#images = Array.isArray(value) ? value : [] }
@@ -142,32 +135,5 @@ export class Estate {
 
   isRealEstateInstance(object){
     return object instanceof Estate
-  }
-
-  hasStandAddress(){
-    return(
-      this.#standAddress?.id === null
-      && this.#standAddress?.street !== undefined
-      && this.#standAddress?.street !== null
-      && this.#standAddress?.street !== ''
-      && this.#standAddress?.number !== undefined
-      && this.#standAddress?.number !== null
-      && this.#standAddress?.neighborhood !== undefined
-      && this.#standAddress?.neighborhood !== null
-      && this.#standAddress?.neighborhood !== ''
-      && this.#standAddress?.city !== undefined
-      && this.#standAddress?.city !== null
-      && this.#standAddress?.city !== ''
-      && this.#standAddress?.uf !== undefined
-      && this.#standAddress?.uf !== null
-      && this.#standAddress?.uf !== ''
-      && this.#standAddress?.region !== undefined
-      && this.#standAddress?.region !== null
-      && this.#standAddress?.region !== ''
-      && this.#standAddress?.zipCode !== undefined
-      && this.#standAddress?.zipCode !== null
-      && this.#standAddress?.zipCode !== ''
-    )
-
   }
 }

--- a/src/app/mappers/advertisementMapper.js
+++ b/src/app/mappers/advertisementMapper.js
@@ -112,7 +112,6 @@ export class AdvertisementMapper {
           ).filter(Boolean)
           : [],
         address: mapAddressToEntity(data.estate.address),
-        standAddress: mapAddressToEntity(data.estate.addressStand),
         amenities: amenitiesSource
           .map(mapFeatureToEntity)
           .filter(Boolean),
@@ -164,7 +163,6 @@ export class AdvertisementMapper {
         ? {
           id: data.eventTypeId.id,
           title: data.eventTypeId.title,
-          slug: data.eventTypeId.slug,
         }
         : null,
     })
@@ -225,19 +223,6 @@ export class AdvertisementMapper {
               // Use 'cep' in the outgoing API payload and include complement if exists
               cep: advertisement.estate.address.zipCode,
               complement: advertisement.estate.address.complement,
-            }
-            : null,
-          addressStand: advertisement.estate.standAddress
-            ? {
-              id: advertisement.estate.standAddress.id,
-              street: advertisement.estate.standAddress.street,
-              number: advertisement.estate.standAddress.number,
-              neighborhood: advertisement.estate.standAddress.neighborhood,
-              city: advertisement.estate.standAddress.city,
-              uf: advertisement.estate.standAddress.uf,
-              region: advertisement.estate.standAddress.region,
-              cep: advertisement.estate.standAddress.zipCode,
-              complement: advertisement.estate.standAddress.complement,
             }
             : null,
           amenities: advertisement.estate.amenities

--- a/src/app/mocks/data/advertisements.json
+++ b/src/app/mocks/data/advertisements.json
@@ -25,7 +25,6 @@
         "zipCode": "01311100",
         "complement": "Apto 80"
       },
-      "standAddress": null,
       "images": [
         {"id": 2001, "url": "https://via.placeholder.com/800x600?text=Cobertura+Bela+Vista", "type": "CAPA"},
         {"id": 2002, "url": "https://via.placeholder.com/800x600?text=Sala+Estar", "type": "GALERIA"}
@@ -60,7 +59,6 @@
         "zipCode": "13092150",
         "complement": null
       },
-      "standAddress": null,
       "images": [
         {"id": 2006, "url": "https://via.placeholder.com/800x600?text=Casa+Conjugado", "type": "CAPA"}
       ],
@@ -94,7 +92,6 @@
         "zipCode": "11060000",
         "complement": "Apto 1205"
       },
-      "standAddress": null,
       "images": [],
       "amenitiesIds": [1, 2, 7, 9]
     },
@@ -126,7 +123,6 @@
         "zipCode": "01305000",
         "complement": "Sala 42"
       },
-      "standAddress": null,
       "images": [],
       "amenitiesIds": [2, 8, 9]
     },
@@ -158,7 +154,6 @@
         "zipCode": "12954000",
         "complement": null
       },
-      "standAddress": null,
       "images": [],
       "amenitiesIds": [5, 6, 10]
     },
@@ -190,7 +185,6 @@
         "zipCode": "05510020",
         "complement": "Apto 15"
       },
-      "standAddress": null,
       "images": [],
       "amenitiesIds": [2, 8]
     },
@@ -222,7 +216,6 @@
         "zipCode": "01311100",
         "complement": "Cj 1400"
       },
-      "standAddress": null,
       "images": [],
       "amenitiesIds": [8, 9]
     },
@@ -254,7 +247,6 @@
         "zipCode": "05409011",
         "complement": "Apto 82"
       },
-      "standAddress": null,
       "images": [],
       "amenitiesIds": [1, 2, 3, 7]
     },
@@ -286,7 +278,6 @@
         "zipCode": "18095200",
         "complement": "Lote 45"
       },
-      "standAddress": null,
       "images": [],
       "amenitiesIds": [7, 8]
     },
@@ -318,7 +309,6 @@
         "zipCode": "13202150",
         "complement": null
       },
-      "standAddress": null,
       "images": [],
       "amenitiesIds": [2, 4]
     },

--- a/src/modules/institutional/components/AdvertisementLocation/AdvertisementLocation.jsx
+++ b/src/modules/institutional/components/AdvertisementLocation/AdvertisementLocation.jsx
@@ -1,8 +1,8 @@
-import { Store, Building } from 'lucide-react'
+import { Building } from 'lucide-react'
 import { HeadingView } from '@shared/components/ui/Heading/HeadingView.jsx'
 import { TextView } from '@shared/components/ui/Text/TextView.jsx'
 
-export function AdvertisementLocation({ address, type }) {
+export function AdvertisementLocation({ address }) {
   const generateMapUrl = (address) => {
     // Use address if available, otherwise use location title/subtitle
     const searchQuery = address?.getFullAddress() || `${address.neighborhood} ${address.city} ${address.state}`
@@ -14,22 +14,12 @@ export function AdvertisementLocation({ address, type }) {
     <div className="flex flex-col h-full gap-subsection md:gap-subsection-md justify-between">
       <div className="flex items-start gap-card md:gap-card-md">
         <div className="bg-default-light rounded-lg p-4">
-          {type === 'stand' ? (
-            <Store size={40} className="text-distac-primary" />
-          ) : type === 'building' ? (
-            <Building size={40} className="text-distac-primary" />
-          ) : null}
+          <Building size={40} className="text-distac-primary" />
         </div>
         <div>
-          {type === 'stand' ? (
-            <HeadingView level={4} className="text-default-light mb-0">
-              Stand de Vendas
-            </HeadingView>
-          ) : type === 'building' ? (
-            <HeadingView level={4} className="text-default-light mb-0">
-              Empreendiento
-            </HeadingView>
-          ) : null}
+          <HeadingView level={4} className="text-default-light mb-0">
+            Localização do Imóvel
+          </HeadingView>
           {address && (
           <TextView className="text-default-light font-medium text-lg mt-3">
             {address.getFullAddress()}

--- a/src/modules/institutional/pages/AdvertisementDetails/AdvertisementDetailsModel.js
+++ b/src/modules/institutional/pages/AdvertisementDetails/AdvertisementDetailsModel.js
@@ -7,11 +7,11 @@ import zonaCentro from '@institutional/assets/regions/zona-central.jpg'
 const REGIONS_LIST = ['sul', 'leste', 'norte', 'oeste', 'centro']
 
 const REGION_TEXTS = {
-  sul: 'A região Sul é referência em qualidade de vida e áreas verdes...',
-  leste: 'A região Leste de São Paulo é ideal para quem busca conveniência...',
-  norte: 'A região Norte de São Paulo oferece um equilíbrio...',
-  oeste: 'A região Oeste é conhecida por seu alto padrão...',
-  centro: 'A região Centro é o coração pulsante da cidade...'
+  sul: 'A região Sul de São Paulo é reconhecida pela excelente qualidade de vida, com ruas arborizadas, ampla presença de parques e uma atmosfera mais tranquila. É uma ótima escolha para quem busca conforto, segurança e proximidade com a natureza, sem abrir mão de boas opções de comércio e serviços.',
+  leste: 'A região Leste de São Paulo se destaca pela praticidade e pelo custo-benefício. Com uma grande variedade de comércios, transporte público acessível e bairros em constante desenvolvimento, é ideal para quem valoriza conveniência no dia a dia e fácil acesso a diferentes pontos da cidade.',
+  norte: 'A região Norte oferece um equilíbrio interessante entre urbanização e áreas verdes. Próxima à Serra da Cantareira, proporciona um clima mais ameno e contato com a natureza, além de contar com infraestrutura crescente, sendo uma boa opção para quem busca tranquilidade com mobilidade.',
+  oeste: 'A região Oeste é conhecida pelo seu alto padrão e infraestrutura completa. Com bairros valorizados, excelente oferta gastronômica, vida cultural ativa e fácil acesso a importantes vias da cidade, é perfeita para quem busca sofisticação, comodidade e qualidade de vida.',
+  centro: 'A região Central é o verdadeiro coração de São Paulo, reunindo diversidade cultural, histórica e urbana. Com acesso facilitado a praticamente toda a cidade, grande oferta de transporte, comércio, serviços e entretenimento, é ideal para quem valoriza praticidade e uma vida dinâmica.'
 }
 
 const REGION_PHOTOS = {

--- a/src/modules/institutional/pages/AdvertisementDetails/AdvertisementDetailsView.jsx
+++ b/src/modules/institutional/pages/AdvertisementDetails/AdvertisementDetailsView.jsx
@@ -12,7 +12,6 @@ import { HeadingView } from '@shared/components/ui/Heading/HeadingView.jsx'
 import { ButtonView } from '@shared/components/ui/Button/ButtonView'
 import { useRouter } from '@app/routes/useRouterViewModel'
 import { ScreeningFormView } from '@shared/components/ui/ScreeningForm/ScreeningFormView.jsx'
-import { X } from 'lucide-react'
 import { AlertView } from '@shared/components/feedback/Alert/AlertView.jsx'
 
 import { useAdvertisementDetailsViewModel } from './useAdvertisementDetailsViewModel'
@@ -142,7 +141,7 @@ export function AdvertisementDetailsView() {
   }
 
   return (
-    <div className="relative h-fit">
+    <div className="relative h-fit pb-24 lg:pb-0">
       {/* Hero */}
       <SectionView className="!p-0">
         <AdvertisementCardView
@@ -213,20 +212,11 @@ export function AdvertisementDetailsView() {
             <HeadingView level={2} className="text-default-light mb-10 text-center md:text-left max-md:!w-full">
               Localização
             </HeadingView>
-            <div className={`grid gap-8 auto-rows-fr ${advertisement.estate?.address && advertisement.estate?.standAddress ? 'grid-cols-1 md:grid-cols-2' : advertisement.estate?.address || advertisement.estate?.standAddress ? 'grid-cols-1' : ''}`}>
-
+            <div className="grid gap-8 auto-rows-fr">
               {advertisement.estate?.address && (
-              <AdvertisementLocation
-                address={advertisement.estate?.address}
-                type="building"
-              />
-              )}
-
-              {advertisement.estate?.hasStandAddress() && (
-              <AdvertisementLocation
-                address={advertisement.estate?.standAddress}
-                type="stand"
-              />
+                <AdvertisementLocation
+                  address={advertisement.estate?.address}
+                />
               )}
             </div>
           </SectionView>
@@ -276,21 +266,20 @@ export function AdvertisementDetailsView() {
         </SectionView>
       )}
 
-      {isScreeningFormOpen && (
-        <div className="fixed inset-0 bg-opacity-30 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto m-4">
-            <div className="flex justify-between items-center mb-4">
-              <HeadingView level={3}>Formulário de Triagem</HeadingView>
-              <button
-                onClick={() => setIsScreeningFormOpen(false)}
-                className="text-gray-500 hover:text-gray-700"
-              >
-                <X size={24} />
-              </button>
-            </div>
-            <ScreeningFormView advertisement={advertisement} onClose={() => setIsScreeningFormOpen(false)} />
-          </div>
+      {advertisement && !isScreeningFormOpen && (
+        <div className="fixed bottom-0 inset-x-0 z-50 lg:hidden bg-default-light/95 backdrop-blur border-t border-default-light-muted p-3">
+          <ButtonView
+            width="full"
+            color="pink"
+            onClick={() => setIsScreeningFormOpen(true)}
+          >
+            Falar com corretor
+          </ButtonView>
         </div>
+      )}
+
+      {isScreeningFormOpen && (
+        <ScreeningFormView advertisement={advertisement} onClose={() => setIsScreeningFormOpen(false)} />
       )}
     </div>
   )

--- a/src/modules/management/pages/Account/AccountView.jsx
+++ b/src/modules/management/pages/Account/AccountView.jsx
@@ -1,6 +1,7 @@
 import { SectionView } from '@shared/components/layout/Section/SectionView'
 import { AlertView } from '@shared/components/feedback/Alert/AlertView'
 import { EditFormView } from '@shared/components/ui/EditForm/EditFormView'
+import { ButtonView } from '@shared/components/ui/Button/ButtonView'
 import { useAccountViewModel } from './useAccountViewModel'
 
 export function AccountView() {
@@ -31,14 +32,41 @@ export function AccountView() {
         onSubmit={vm.handleSubmit}
         onDelete={vm.handleDelete}
         showDeleteButton={true}
+        useNativeDeleteConfirm={false}
       />
 
       <AlertView
         isVisible={!!vm.alertConfig}
         type={vm.alertConfig?.type}
         message={vm.alertConfig?.message}
+        hasCloseButton={!vm.alertConfig?.isConfirm}
         onClose={vm.handleCloseAlert}
-      />
+        buttonsLayout="col"
+      >
+        {vm.alertConfig?.isConfirm && (
+          <div className="flex justify-center gap-card md:gap-card-md w-full">
+            <ButtonView
+              type="button"
+              shape="square"
+              color="border-distac-primary"
+              onClick={vm.handleCloseAlert}
+              width="fit"
+            >
+              Cancelar
+            </ButtonView>
+            <ButtonView
+              type="button"
+              shape="square"
+              color="pink"
+              onClick={vm.handleConfirmDelete}
+              width="fit"
+              disabled={vm.isDeleting}
+            >
+              {vm.isDeleting ? 'Excluindo...' : (vm.alertConfig?.confirmText || 'Confirmar')}
+            </ButtonView>
+          </div>
+        )}
+      </AlertView>
     </SectionView>
   )
 }

--- a/src/modules/management/pages/Account/useAccountViewModel.js
+++ b/src/modules/management/pages/Account/useAccountViewModel.js
@@ -10,6 +10,7 @@ export function useAccountViewModel() {
     newPassword: ''
   })
   const [isLoading, setIsLoading] = useState(true)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState(null)
   const [alertConfig, setAlertConfig] = useState(null)
 
@@ -91,15 +92,13 @@ export function useAccountViewModel() {
     }
   }
 
-  const handleDelete = async () => {
+  const executeDelete = async () => {
     try {
+      setIsDeleting(true)
       const userId = sessionStorage.getItem('userId')
       if (!userId) {
         throw new Error('Usuário não encontrado')
       }
-
-      const confirmed = window.confirm('Tem certeza que deseja excluir sua conta? Esta ação não pode ser desfeita.')
-      if (!confirmed) return
 
       await deleteUser(userId)
 
@@ -119,8 +118,25 @@ export function useAccountViewModel() {
         type: 'error',
         message: err.message || 'Erro ao excluir conta'
       })
+    } finally {
+      setIsDeleting(false)
     }
   }
+
+  const handleDelete = useCallback(() => {
+    setAlertConfig({
+      type: 'warning',
+      isConfirm: true,
+      message: 'Tem certeza que deseja excluir sua conta? Esta ação não pode ser desfeita.',
+      confirmText: 'Excluir conta',
+    })
+  }, [])
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!alertConfig?.isConfirm || isDeleting) return
+    setAlertConfig(null)
+    await executeDelete()
+  }, [alertConfig, isDeleting])
 
   const handleCloseAlert = useCallback(() => {
     const onClose = alertConfig?.onClose
@@ -135,10 +151,12 @@ export function useAccountViewModel() {
     accountFields,
     formData,
     isLoading,
+    isDeleting,
     error,
     alertConfig,
     handleSubmit,
     handleDelete,
+    handleConfirmDelete,
     handleCloseAlert,
     model,
   }

--- a/src/modules/management/pages/AdvertisementConfig/AdvertisementConfigModel.js
+++ b/src/modules/management/pages/AdvertisementConfig/AdvertisementConfigModel.js
@@ -50,24 +50,6 @@ export class AdvertisementConfigModel {
     }
 
 
-
-    // Stand address
-    const standAddressData = estate?.standAddress
-
-
-    this.standAddress = {
-      cep: standAddressData?.zipCode || '',
-      number: standAddressData?.number || '',
-      region: standAddressData?.region || '',
-      street: standAddressData?.street || '',
-      neighborhood: standAddressData?.neighborhood || '',
-      city: standAddressData?.city || '',
-      state: standAddressData?.uf || ''
-    }
-
-    this.enableStandAddress = !!standAddressData && Object.values(standAddressData).some(v => v)
-
-
     // Images
     const images = estate?.images || []
 
@@ -254,14 +236,6 @@ export class AdvertisementConfigModel {
       neighborhood: this.address.neighborhood,
       city: this.address.city,
       state: this.address.state,
-      standCep: this.standAddress.cep,
-      standNumber: this.standAddress.number,
-      standRegion: this.standAddress.region,
-      standStreet: this.standAddress.street,
-      standNeighborhood: this.standAddress.neighborhood,
-      standCity: this.standAddress.city,
-      standState: this.standAddress.state,
-      enableStandAddress: this.enableStandAddress,
       video: this.images.video,
       cover: this.images.cover,
       gallery: this.images.gallery,
@@ -513,17 +487,6 @@ export class AdvertisementConfigModel {
           complement: null,
           region: sanitizeString(formData.region, 50)
         },
-        addressStand: (formData.enableStandAddress && formData.standStreet) ? {
-          id: this.originalAdvertisementData?.estate?.standAddress?.id || null,
-          street: sanitizeString(formData.standStreet, 255),
-          number: sanitizeString(formData.standNumber, 20),
-          neighborhood: sanitizeString(formData.standNeighborhood, 100),
-          city: sanitizeString(formData.standCity, 100),
-          uf: sanitizeString(formData.standState, 2),
-          zipCode: formatCep(formData.standCep),
-          complement: null,
-          region: sanitizeString(formData.standRegion, 50)
-        } : null,
         amenitiesIds: mapDifferentialsToIds(formData.differentials),
         images
       }

--- a/src/modules/management/pages/Schedule/AppointmentFormModalView.jsx
+++ b/src/modules/management/pages/Schedule/AppointmentFormModalView.jsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 import { X, AlertCircle, Check, Image as ImageIcon } from 'lucide-react'
 import { ButtonView } from '@shared/components/ui/Button/ButtonView'
 import { HeadingView } from '@shared/components/ui/Heading/HeadingView'
+import { formatPhoneNumber } from '@shared/utils/phone/formatPhoneNumberUtil'
 import { useAppointmentFormViewModel } from './useAppointmentFormViewModel'
 
 export function AppointmentFormModalView({
@@ -68,7 +69,7 @@ export function AppointmentFormModalView({
   }
 
   const handleVisitorPhoneChange = (e) => {
-    vm.updateField('visitorPhone', e.target.value)
+    vm.updateField('visitorPhone', formatPhoneNumber(e.target.value))
   }
 
   const handleNotesChange = (e) => {
@@ -240,6 +241,7 @@ export function AppointmentFormModalView({
                 placeholder="Telefone do visitante"
                 value={vm.model.visitorPhone}
                 onChange={handleVisitorPhoneChange}
+                maxLength={15}
                 className="w-full px-3 py-2 border border-slate-200 rounded-lg focus:ring-2 focus:ring-distac-primary focus:border-transparent outline-none"
               />
             </div>

--- a/src/shared/components/layout/NavMenu/NavMenuView.jsx
+++ b/src/shared/components/layout/NavMenu/NavMenuView.jsx
@@ -181,7 +181,7 @@ export function NavMenuView({
   if (variant === 'footer') {
     return (
       <div className={viewModel.getFooterClasses()}>
-        <div className='flex flex-col items-center md:items-start justify-between h-24 col-span-2 md:col-span-1'>
+        <div className='flex flex-col items-center md:items-start justify-between h-24 col-span-1'>
           <LogoView hasHoverEffect={true} />
           <HeadingView level={4} className='text-center text-distac-primary md:text-start'>
             Seu sonho começa com uma chave

--- a/src/shared/components/ui/Chatbot/ChatbotModel.js
+++ b/src/shared/components/ui/Chatbot/ChatbotModel.js
@@ -58,7 +58,7 @@ export const chatbotModel = {
 
     agendamento: {
       botResponse:
-        'Perfeito! Trabalhamos com Visitas Presenciais aos nossos Stands, e visitas totalmente Online. Deseja agendar uma visita?',
+        'Perfeito! Trabalhamos com visitas presenciais e visitas totalmente online. Deseja agendar uma visita?',
       options: [
         'Agendar agora!',
         'Voltar para o inicio',

--- a/src/shared/components/ui/EditForm/EditFormView.jsx
+++ b/src/shared/components/ui/EditForm/EditFormView.jsx
@@ -27,6 +27,7 @@ export function EditFormView({
   onDelete,
   isEditing: initialIsEditing = false,
   showDeleteButton = true,
+  useNativeDeleteConfirm = true,
 }) {
   const vm = useEditFormViewModel({
     title,
@@ -36,6 +37,7 @@ export function EditFormView({
     onCancel,
     onDelete,
     isEditing: initialIsEditing,
+    useNativeDeleteConfirm,
   })
 
   // Função para verificar se um campo deve ser exibido com base em condições
@@ -135,6 +137,7 @@ export function EditFormView({
                         name={field.name}
                         type={field.type || 'text'}
                         value={vm.getFieldValue(field.name)}
+                        maxLength={/cep|zipcode/i.test(field.name || '') ? 9 : /cpf/i.test(field.name || '') ? 14 : /phone|telefone|celular|whatsapp/i.test(field.name || '') ? 15 : field.maxLength}
                         hasLabel={Boolean(field.label)}
                         disabled={true}
                         isActive={false}
@@ -252,6 +255,7 @@ export function EditFormView({
                       disabled={field.disabled}
                       formatOnChange={field.formatOnChange}
                       formatter={field.formatter}
+                      maxLength={/cep|zipcode/i.test(field.name || '') ? 9 : /cpf/i.test(field.name || '') ? 14 : /phone|telefone|celular|whatsapp/i.test(field.name || '') ? 15 : field.maxLength}
                     >
                       {field.label || ''}
                     </InputView>

--- a/src/shared/components/ui/EditForm/useEditFormViewModel.js
+++ b/src/shared/components/ui/EditForm/useEditFormViewModel.js
@@ -1,4 +1,61 @@
 import { useState, useEffect, useCallback } from 'react'
+import { formatCEP } from '@shared/utils/CEP/formatCEPUtil'
+import { formatCPF } from '@shared/utils/CPF/formatCPFUtil'
+import { formatPhoneNumber } from '@shared/utils/phone/formatPhoneNumberUtil'
+
+const CEP_FIELD_NAME_REGEX = /cep|zipcode/i
+const CPF_FIELD_NAME_REGEX = /cpf/i
+const PHONE_FIELD_NAME_REGEX = /phone|telefone|celular|whatsapp/i
+
+function isMaskableValue(value) {
+  return typeof value === 'string' || typeof value === 'number'
+}
+
+function shouldApplyCEPMask(field = {}) {
+  return CEP_FIELD_NAME_REGEX.test(field.name || '')
+}
+
+function shouldApplyCPFMask(field = {}) {
+  return CPF_FIELD_NAME_REGEX.test(field.name || '')
+}
+
+function shouldApplyPhoneMask(field = {}) {
+  return PHONE_FIELD_NAME_REGEX.test(field.name || '')
+}
+
+function applyInitialFieldMasks(data = {}, fields = []) {
+  const maskedData = { ...data }
+
+  fields.forEach((field) => {
+    if (!field?.name) return
+
+    const value = maskedData[field.name]
+    if (value === undefined || value === null || value === '' || !isMaskableValue(value)) {
+      return
+    }
+
+    if (field.formatOnChange && typeof field.formatter === 'function') {
+      maskedData[field.name] = field.formatter(String(value))
+      return
+    }
+
+    if (shouldApplyCEPMask(field)) {
+      maskedData[field.name] = formatCEP(String(value))
+      return
+    }
+
+    if (shouldApplyCPFMask(field)) {
+      maskedData[field.name] = formatCPF(String(value))
+      return
+    }
+
+    if (shouldApplyPhoneMask(field)) {
+      maskedData[field.name] = formatPhoneNumber(String(value))
+    }
+  })
+
+  return maskedData
+}
 
 export function useEditFormViewModel({
   title = '',
@@ -8,6 +65,7 @@ export function useEditFormViewModel({
   onCancel,
   onDelete,
   isEditing: initialIsEditing = false,
+  useNativeDeleteConfirm = true,
 }) {
   const [isEditing, setIsEditing] = useState(initialIsEditing)
   const [formData, setFormData] = useState({})
@@ -15,20 +73,15 @@ export function useEditFormViewModel({
   const [isLoading, setIsLoading] = useState(false)
   const [successMessage, setSuccessMessage] = useState('')
 
-  // Inicializar formData com dados iniciais
+  // Sincronizar formData quando initialData muda, aplicando máscaras de campos
   useEffect(() => {
-    if (Object.keys(initialData).length > 0) {
-      setFormData(initialData)
-    }
-  }, [initialData])
+    const maskedInitialData = applyInitialFieldMasks(initialData, fields)
 
-  // Sincronizar formData quando initialData muda
-  useEffect(() => {
     setFormData(prevData => ({
       ...prevData,
-      ...initialData
+      ...maskedInitialData
     }))
-  }, [initialData])
+  }, [initialData, fields])
 
   const getFieldValue = useCallback((fieldName) => {
     return formData[fieldName] || ''
@@ -45,6 +98,21 @@ export function useEditFormViewModel({
       // Aplicar formatação se o campo tiver formatter e formatOnChange
       if (field && field.formatOnChange && field.formatter && typeof field.formatter === 'function') {
         processedValue = field.formatter(value)
+      }
+
+      // Garantir máscara de CEP em qualquer campo de CEP, mesmo sem formatter explícito
+      if (field && shouldApplyCEPMask(field) && isMaskableValue(processedValue)) {
+        processedValue = formatCEP(String(processedValue))
+      }
+
+      // Garantir máscara de CPF em qualquer campo de CPF, mesmo sem formatter explícito
+      if (field && shouldApplyCPFMask(field) && isMaskableValue(processedValue)) {
+        processedValue = formatCPF(String(processedValue))
+      }
+
+      // Garantir máscara de telefone em qualquer campo de telefone, mesmo sem formatter explícito
+      if (field && shouldApplyPhoneMask(field) && isMaskableValue(processedValue)) {
+        processedValue = formatPhoneNumber(String(processedValue))
       }
 
       setFormData(prev => {
@@ -153,24 +221,26 @@ export function useEditFormViewModel({
     setSuccessMessage('')
 
     // Restaurar dados iniciais
-    setFormData(initialData)
+    setFormData(applyInitialFieldMasks(initialData, fields))
 
     onCancel?.()
-  }, [initialData, onCancel])
+  }, [initialData, fields, onCancel])
 
   const handleDelete = useCallback(async () => {
-    if (window.confirm('Tem certeza que deseja excluir este item?')) {
-      setIsLoading(true)
-      try {
-        await onDelete?.()
-      } catch (error) {
-        console.error('Erro ao excluir:', error)
-        setErrors({ general: 'Erro ao excluir. Tente novamente.' })
-      } finally {
-        setIsLoading(false)
-      }
+    if (useNativeDeleteConfirm && !window.confirm('Tem certeza que deseja excluir este item?')) {
+      return
     }
-  }, [onDelete])
+
+    setIsLoading(true)
+    try {
+      await onDelete?.()
+    } catch (error) {
+      console.error('Erro ao excluir:', error)
+      setErrors({ general: 'Erro ao excluir. Tente novamente.' })
+    } finally {
+      setIsLoading(false)
+    }
+  }, [onDelete, useNativeDeleteConfirm])
 
   return {
     // Estado

--- a/src/shared/components/ui/Form/FormView.jsx
+++ b/src/shared/components/ui/Form/FormView.jsx
@@ -6,6 +6,7 @@ import { ErrorDisplayView } from '@shared/components/feedback/ErrorDisplay/Error
 import { TextView } from '@shared/components/ui/Text/TextView'
 import { HeadingView } from '@shared/components/ui/Heading/HeadingView'
 import { useFormViewModel } from '@shared/components/ui/Form/useFormViewModel'
+import { Info } from 'lucide-react'
 
 /**
  * FormView - Componente de formulário genérico
@@ -154,6 +155,7 @@ export function FormView({
               inputMode={field.inputMode}
               isActive={!formIsLoading}
               link={field.link}
+              checkboxCentered={field.checkboxCentered}
             >
               {field.label || ''}
             </InputView>
@@ -168,8 +170,9 @@ export function FormView({
 
           {/* Texto auxiliar/informativo */}
           {field.helperText && (
-            <div className="text-default-dark-muted text-m mt-2 font-bold">
-              {field.helperText}
+            <div className="flex items-center justify-center gap-2 text-default-dark-muted text-m mt-2 font-bold text-center w-full">
+              {field.helperIcon === 'info' && <Info size={16} aria-hidden="true" className="shrink-0" />}
+              <span>{field.helperText}</span>
             </div>
           )}
         </div>

--- a/src/shared/components/ui/Input/InputView.jsx
+++ b/src/shared/components/ui/Input/InputView.jsx
@@ -179,6 +179,7 @@ export function InputView({
   onChange,
   onClick,
   link = null,
+  checkboxCentered = false,
   // Props customizadas que não devem ir para o input HTML
   formatOnChange = false,
   formatter = null,
@@ -276,7 +277,7 @@ export function InputView({
             : 'bg-distac-primary-light'
         }`}
         >
-          <label className={`flex items-start gap-2 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}>
+          <label className={`flex gap-2 w-full ${checkboxCentered ? 'flex-col md:flex-row items-center justify-center text-center gap-3 md:gap-2' : 'items-start'} ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}>
             <input
               className={inputClasses}
               type="checkbox"
@@ -289,7 +290,7 @@ export function InputView({
               onClick={onClick}
               {...htmlProps}
             />
-            <span className={`text-[12px] md:text-[16px] text-default-dark flex-1`}>
+            <span className={`text-[12px] md:text-[16px] text-default-dark ${checkboxCentered ? 'w-full max-w-none md:max-w-4xl text-center leading-relaxed' : 'flex-1'}`}>
               {placeholder || label}
               {link && (
                 <>

--- a/src/shared/components/ui/ScreeningForm/ScreeningFormModel.js
+++ b/src/shared/components/ui/ScreeningForm/ScreeningFormModel.js
@@ -58,9 +58,11 @@ export const ScreeningFormModel = {
       hasLabel: false,
       required: true,
       column: 3,
+      checkboxCentered: true,
       label: 'Aceito os termos da Lei Geral de Proteção de Dados (LGPD) e autorizo o uso das minhas informações pessoais para os fins descritos.',
       link: { text: 'Saiba mais sobre LGPD', url: 'https://www.gov.br/cidadania/pt-br/acesso-a-informacao/lgpd' },
-      helperText: 'ℹ️ Os dados preenchidos neste formulário não serão salvos, seu uso é exclusivamente para facilitar a comunicação entre você e nosso especialista.'
+      helperIcon: 'info',
+      helperText: 'Os dados preenchidos neste formulário não serão salvos, seu uso é exclusivamente para facilitar a comunicação entre você e nosso especialista.'
     },
   ],
 

--- a/src/shared/components/ui/ScreeningForm/ScreeningFormView.jsx
+++ b/src/shared/components/ui/ScreeningForm/ScreeningFormView.jsx
@@ -22,16 +22,16 @@ export function ScreeningFormView({ onClose, advertisement = null }) {
   } = useScreeningFormViewModel(advertisement)
 
   return ReactDOM.createPortal(
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50">
-      <div className="relative bg-default-light rounded-lg shadow-2xl p-16 w-full max-w-6xl mx-4 border-2 border-distac-primary flex flex-col space-y-6">
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-2 md:p-4">
+      <div className="relative bg-default-light rounded-lg shadow-2xl p-4 md:p-10 lg:p-16 w-full max-w-6xl border-2 border-distac-primary flex flex-col space-y-6 max-h-[92vh] overflow-y-auto">
 
         <HeadingView
           level={4}
-          className="grid grid-cols-3 items-center w-full mb-10 text-distac-primary font-semibold"
+          className="grid grid-cols-[1fr_auto] md:grid-cols-3 items-center w-full mb-6 md:mb-10 text-distac-primary font-semibold gap-2"
         >
-          <div></div>
+          <div className="hidden md:block"></div>
 
-          <div className="text-center">Formulário de Triagem</div>
+          <div className="text-center md:text-center">Formulário de Triagem</div>
 
           <div className="flex justify-end">
             <ButtonView
@@ -63,22 +63,20 @@ export function ScreeningFormView({ onClose, advertisement = null }) {
           />
         </div>
 
-        {/* Campo LGPD centralizado */}
-        <div className="w-full flex justify-center">
-          <div className="w-full md:w-2/3">
-            <FormView
-              fields={fieldsColumn3}
-              onChange={handleFieldChange}
-              submitText=""
-            />
-          </div>
+        {/* Campo LGPD de ponta a ponta */}
+        <div className="w-full">
+          <FormView
+            fields={fieldsColumn3}
+            onChange={handleFieldChange}
+            submitText=""
+          />
         </div>
 
         <div className="w-full flex justify-center mt-6">
           <ButtonView
             width="full"
             onClick={enviarWhatsApp}
-            className="w-1/3"
+            className="w-full md:w-1/3"
           >
             Enviar pelo WhatsApp
           </ButtonView>

--- a/src/shared/components/ui/WizardForm/WizardFormModel.js
+++ b/src/shared/components/ui/WizardForm/WizardFormModel.js
@@ -1,3 +1,56 @@
+import { formatCEP } from '@shared/utils/CEP/formatCEPUtil'
+import { formatCPF } from '@shared/utils/CPF/formatCPFUtil'
+import { formatPhoneNumber } from '@shared/utils/phone/formatPhoneNumberUtil'
+
+const CEP_FIELD_NAME_REGEX = /cep|zipcode/i
+const CPF_FIELD_NAME_REGEX = /cpf/i
+const PHONE_FIELD_NAME_REGEX = /phone|telefone|celular|whatsapp/i
+
+function isMaskableValue(value) {
+  return typeof value === 'string' || typeof value === 'number'
+}
+
+function getAllFieldsFromSteps(steps = []) {
+  return (steps || []).flatMap(step =>
+    (step.groups || []).flatMap(group => group.fields || [])
+  )
+}
+
+function normalizeInitialFieldValues(initialData = {}, steps = []) {
+  const normalizedData = { ...initialData }
+  const fields = getAllFieldsFromSteps(steps)
+
+  fields.forEach((field) => {
+    if (!field?.name) return
+
+    const value = normalizedData[field.name]
+    if (value === undefined || value === null || value === '' || !isMaskableValue(value)) {
+      return
+    }
+
+    if (field.formatOnChange && typeof field.formatter === 'function') {
+      normalizedData[field.name] = field.formatter(String(value))
+      return
+    }
+
+    if (CEP_FIELD_NAME_REGEX.test(field.name)) {
+      normalizedData[field.name] = formatCEP(String(value))
+      return
+    }
+
+    if (CPF_FIELD_NAME_REGEX.test(field.name)) {
+      normalizedData[field.name] = formatCPF(String(value))
+      return
+    }
+
+    if (PHONE_FIELD_NAME_REGEX.test(field.name)) {
+      normalizedData[field.name] = formatPhoneNumber(String(value))
+    }
+  })
+
+  return normalizedData
+}
+
 /**
  * WizardFormModel - Modelo de dados para formulários em etapas (wizard)
  */
@@ -14,7 +67,7 @@ export class WizardFormModel {
     this.title = title
     this.steps = steps
     this.currentStep = 0
-    this.fieldValues = { ...initialData }
+    this.fieldValues = normalizeInitialFieldValues(initialData, steps)
     this.fieldErrors = {}
     this.onSubmit = onSubmit
     this.onDelete = onDelete

--- a/src/shared/components/ui/WizardForm/WizardFormView.jsx
+++ b/src/shared/components/ui/WizardForm/WizardFormView.jsx
@@ -173,32 +173,6 @@ export function WizardFormView(props) {
     }
   )
 
-  // Hook para preenchimento automático de CEP do STAND
-  const cepAutoFillStand = useCEPAutoFill(
-    (addressData) => {
-      // Preencher apenas campos do STAND
-      if (addressData.street) {
-        vm.handleFieldChange('standStreet')(addressData.street)
-      }
-      if (addressData.neighborhood) {
-        vm.handleFieldChange('standNeighborhood')(addressData.neighborhood)
-      }
-      if (addressData.city) {
-        vm.handleFieldChange('standCity')(addressData.city)
-      }
-      if (addressData.uf) {
-        vm.handleFieldChange('standState')(addressData.uf)
-      }
-    },
-    {
-      debounceDelay: 800,
-      enableAutoFill: true,
-      onError: (error) => {
-        showAlert(error, 'warning')
-      }
-    }
-  )
-
   const renderField = (field) => {
     const commonProps = {
       id: field.name,
@@ -211,16 +185,7 @@ export function WizardFormView(props) {
       className: field.className || '',
     }
 
-    // Verificar se é um campo do stand e se deve ser desabilitado
-    const isStandField = field.name.startsWith('stand') && field.name !== 'enableStandAddress'
-    const standEnabled = Boolean(vm.getFieldValue('enableStandAddress'))
-
-    // Se é campo do stand e o checkbox não está marcado, desabilitar
-    if (isStandField && !standEnabled) {
-      commonProps.disabled = true
-    } else {
-      commonProps.disabled = field.disabled || false
-    }
+    commonProps.disabled = field.disabled || false
 
     // Aplicar formatação para campos específicos
     if (field.name === 'area' && field.type === 'text') {
@@ -249,6 +214,7 @@ export function WizardFormView(props) {
     if (field.name === 'cep' && field.type === 'text') {
       commonProps.formatOnChange = true
       commonProps.formatter = formatCEP
+      commonProps.maxLength = 9
 
       const originalOnChange = commonProps.onChange
       commonProps.onChange = (value) => {
@@ -261,22 +227,12 @@ export function WizardFormView(props) {
       }
     }
 
-    // Aplicar formatação para CEP do STAND
-    if (field.name === 'standCep' && field.type === 'text') {
-      commonProps.formatOnChange = true
-      commonProps.formatter = formatCEP
+    if (/cpf/i.test(field.name || '')) {
+      commonProps.maxLength = 14
+    }
 
-      const originalOnChange = commonProps.onChange
-      commonProps.onChange = (value) => {
-        originalOnChange(value)
-
-        // Disparar busca automática apenas para campos do STAND (se habilitado)
-        if (standEnabled) {
-          setTimeout(() => {
-            cepAutoFillStand.searchCEP(value)
-          }, 100)
-        }
-      }
+    if (/phone|telefone|celular|whatsapp/i.test(field.name || '')) {
+      commonProps.maxLength = 15
     }
 
     if (field.type === 'heading') {
@@ -898,6 +854,9 @@ export function WizardFormView(props) {
         hasLabel={commonProps.hasLabel}
         required={commonProps.required}
         disabled={commonProps.disabled}
+        formatOnChange={commonProps.formatOnChange}
+        formatter={commonProps.formatter}
+        maxLength={commonProps.maxLength}
         type={field.type || 'text'}
         placeholder={field.placeholder || field.label || ''}
         className={commonProps.className}

--- a/src/shared/styles/theme.js
+++ b/src/shared/styles/theme.js
@@ -279,7 +279,7 @@ export const theme = {
     },
     footer: {
       container: [
-        'grid grid-cols-2 gap-6 items-start',
+        'grid grid-cols-1 gap-6 items-start justify-items-center',
         'md:flex md:flex-row md:items-start md:justify-between md:w-full md:h-fit md:gap-0'
       ].join(' '),
       logoSection: 'flex flex-col items-center md:items-start justify-between h-24',

--- a/src/shared/utils/CEP/formatCEPUtil.js
+++ b/src/shared/utils/CEP/formatCEPUtil.js
@@ -9,7 +9,7 @@ export function formatCEP(cep) {
   if (!cep) return ''
 
   // Remove tudo que não é número
-  const cleanCep = cep.replace(/\D/g, '')
+  const cleanCep = String(cep).replace(/\D/g, '').slice(0, 8)
 
   // Se tem 8 dígitos (CEP completo)
   if (cleanCep.length === 8) {

--- a/src/shared/utils/CPF/formatCPFUtil.js
+++ b/src/shared/utils/CPF/formatCPFUtil.js
@@ -9,7 +9,7 @@ export function formatCPF(cpf) {
   if (!cpf) return ''
 
   // Remove tudo que não é número
-  const cleanCpf = cpf.replace(/\D/g, '')
+  const cleanCpf = String(cpf).replace(/\D/g, '').slice(0, 11)
 
   // Se tem 11 dígitos (CPF completo)
   if (cleanCpf.length === 11) {
@@ -41,5 +41,5 @@ export function formatCPF(cpf) {
  */
 export function cleanCPF(cpf) {
   if (!cpf) return ''
-  return cpf.replace(/\D/g, '')
+  return String(cpf).replace(/\D/g, '').slice(0, 11)
 }

--- a/src/shared/utils/CPF/validateCPFUtil.js
+++ b/src/shared/utils/CPF/validateCPFUtil.js
@@ -7,7 +7,7 @@
  */
 export function validateCPF(cpf) {
   // Remove tudo que não é número
-  cpf = cpf.replace(/[^\d]+/g, '')
+  cpf = String(cpf ?? '').replace(/[^\d]+/g, '').slice(0, 11)
 
   if (cpf.length !== 11) return false
 

--- a/src/shared/utils/phone/formatPhoneNumberUtil.js
+++ b/src/shared/utils/phone/formatPhoneNumberUtil.js
@@ -10,7 +10,7 @@ export function formatPhoneNumber(phone) {
   if (!phone) return ''
 
   // Remove tudo que não é número
-  const cleanPhone = phone.replace(/\D/g, '')
+  const cleanPhone = String(phone).replace(/\D/g, '').slice(0, 11)
 
   // Se tem 11 dígitos (celular com 9)
   if (cleanPhone.length === 11) {
@@ -47,5 +47,5 @@ export function formatPhoneNumber(phone) {
  */
 export function cleanPhoneNumber(phone) {
   if (!phone) return ''
-  return phone.replace(/\D/g, '')
+  return String(phone).replace(/\D/g, '').slice(0, 11)
 }


### PR DESCRIPTION
remove standAddress do modelo Estate e componentes relacionados

Removida a propriedade #standAddress da classe Estate e seus métodos associados.
Atualizado o AdvertisementMapper para excluir o mapeamento de standAddress.
Modificados os dados mock de anúncios para remover referências a standAddress.
Ajustado o componente AdvertisementLocation para simplificar o tratamento de endereço.
Refatorado o AdvertisementDetailsView para remover verificações de standAddress.
Aprimorado o AccountView para melhorar o tratamento de confirmação de exclusão.
Atualizado o tratamento de formulários em vários componentes para aplicar máscaras de entrada para CEP, CPF e números de telefone.
Melhorados os componentes de UI para melhor layout e acessibilidade.